### PR TITLE
Version alpha-v1.0.0 - ChangeLog

### DIFF
--- a/app/src/androidTest/java/com/ruben/covid_19_statistics_app/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/ruben/covid_19_statistics_app/ExampleInstrumentedTest.java
@@ -49,9 +49,34 @@ public class ExampleInstrumentedTest {
         onView(withId(R.id.list_with_finder_layout_no_elements_find_wrapper)).check(matches(isDisplayed()));
     }
 
+    @Test
+    public void selectRegionTest() {
+        sleep();
+        onView(withHint("Country...")).perform(typeText("China"), ViewActions.closeSoftKeyboard());
+        onView(withId(R.id.item_name)).perform(click());
+    }
 
+    @Test
+    public void selectProvinceTest() {
+        sleep();
+        onView(withHint("Country...")).perform(typeText("China"), ViewActions.closeSoftKeyboard());
+        onView(withId(R.id.item_name)).perform(click());
+        sleep();
+        onView(withText("Anhui")).perform(click());
+    }
 
     // This test is a happy path test :)
+    @Test
+    public void selectRegionAsFavourite() {
+        sleep();
+        onView(withHint("Country...")).perform(typeText("China"), ViewActions.closeSoftKeyboard());
+        onView(withId(R.id.item_name)).perform(click());
+        sleep();
+        onView(withText("Anhui")).perform(click());
+        sleep();
+        onView(withId(R.id.report_fragment_star_button)).perform(click());
+    }
+
     @Test
     public void closeFavDialog() {
         sleep();
@@ -61,7 +86,5 @@ public class ExampleInstrumentedTest {
         onView(withText("Anhui")).perform(click());
         sleep();
         onView(withId(R.id.report_fragment_star_button)).perform(click());
-        sleep();
-        onView(withId(R.id.available_in_future_versions_pop_up)).perform(click());
     }
 }

--- a/app/src/androidTest/java/com/ruben/covid_19_statistics_app/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/ruben/covid_19_statistics_app/ExampleInstrumentedTest.java
@@ -49,25 +49,11 @@ public class ExampleInstrumentedTest {
         onView(withId(R.id.list_with_finder_layout_no_elements_find_wrapper)).check(matches(isDisplayed()));
     }
 
-    @Test
-    public void selectRegionTest() {
-        sleep();
-        onView(withHint("Country...")).perform(typeText("China"), ViewActions.closeSoftKeyboard());
-        onView(withId(R.id.item_name)).perform(click());
-    }
 
-    @Test
-    public void selectProvinceTest() {
-        sleep();
-        onView(withHint("Country...")).perform(typeText("China"), ViewActions.closeSoftKeyboard());
-        onView(withId(R.id.item_name)).perform(click());
-        sleep();
-        onView(withText("Anhui")).perform(click());
-    }
 
     // This test is a happy path test :)
     @Test
-    public void selectRegionAsFavourite() {
+    public void closeFavDialog() {
         sleep();
         onView(withHint("Country...")).perform(typeText("China"), ViewActions.closeSoftKeyboard());
         onView(withId(R.id.item_name)).perform(click());
@@ -75,5 +61,7 @@ public class ExampleInstrumentedTest {
         onView(withText("Anhui")).perform(click());
         sleep();
         onView(withId(R.id.report_fragment_star_button)).perform(click());
+        sleep();
+        onView(withId(R.id.available_in_future_versions_pop_up)).perform(click());
     }
 }

--- a/app/src/main/res/layout/report_fragment.xml
+++ b/app/src/main/res/layout/report_fragment.xml
@@ -69,11 +69,11 @@
 
             <ImageView
                 android:id="@+id/report_fragment_star_button"
-                android:layout_width="45dp"
-                android:layout_height="45dp"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
                 android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
                 android:layout_marginRight="20dp"
+                android:layout_marginTop="10dp"
                 android:src="@drawable/ic_star_not_selected" />
 
         </RelativeLayout>


### PR DESCRIPTION
# DaCovid first functionalities!! 

The app is now functional, you can do some things like:
1. Filter the preferred region from the initial region list
2. Select a province of a region to see the covid statistics
3. See the covid data of the selected province including a map to see where the province is located in the world (Using google maps sdk)

The covid data you can consult from the selected province are:
1. The recovered patients of the day
2. The total deaths
3. The confirmed cases of the day

This data will be improving in the next versions of the app